### PR TITLE
GADGETS-26 Refactored poms to use jbossas parent and bom

### DIFF
--- a/distribution/src/main/assembly/bin.xml
+++ b/distribution/src/main/assembly/bin.xml
@@ -20,7 +20,7 @@
 -->
 <assembly>
     <!-- id typically identifies the "type" (src vs bin etc) of the assembly -->
-    <id></id>
+    <id>bin</id>
     <includeBaseDirectory>true</includeBaseDirectory>
     <formats>
         <format>zip</format>

--- a/gadget-core/pom.xml
+++ b/gadget-core/pom.xml
@@ -4,7 +4,6 @@
   <groupId>org.overlord.gadgets.server</groupId>
   <artifactId>gadget-core</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.0-SNAPSHOT</version>
   <name>Gadget Server::Core</name>
 
   <parent>
@@ -17,7 +16,6 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-	  <version>${guice.version}</version>
     </dependency>
 
     <!--dependency>
@@ -29,29 +27,24 @@
     <dependency>
       <groupId>org.hibernate.javax.persistence</groupId>
       <artifactId>hibernate-jpa-2.0-api</artifactId>
-      <version>${persistence-api.version}</version>
     </dependency>
     <dependency>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-core</artifactId>
-        <version>${hibernate.version}</version>
     </dependency>
     <dependency>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-entitymanager</artifactId>
-        <version>${hibernate.version}</version>
     </dependency>
 
     <dependency>
-        <groupId>javassist</groupId>
+        <groupId>org.javassist</groupId>
         <artifactId>javassist</artifactId>
-        <version>${javassist.version}</version>
     </dependency>
 
     <dependency>
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
-        <version>${h2.version}</version>
     </dependency>
 
       <!-- Shindig -->
@@ -60,7 +53,6 @@
           <artifactId>shindig-common</artifactId>
           <type>jar</type>
           <scope>compile</scope>
-          <version>${shindig.version}</version>
           <exclusions>
               <exclusion>
                   <groupId>org.apache.tomcat</groupId>
@@ -77,13 +69,11 @@
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
          <scope>test</scope>
-         <version>4.10</version>
      </dependency>
 
       <dependency>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
-          <version>${log4j.version}</version>
       </dependency>
 
   </dependencies>

--- a/gadget-server/pom.xml
+++ b/gadget-server/pom.xml
@@ -4,7 +4,6 @@
   <groupId>org.overlord.gadgets.server</groupId>
   <artifactId>gadget-server</artifactId>
   <packaging>war</packaging>
-  <version>1.0.0-SNAPSHOT</version>
   <name>Gadget Server::Server</name>
 
   <parent>
@@ -17,18 +16,15 @@
 	<dependency>
         <groupId>org.apache.shindig</groupId>
         <artifactId>shindig-server</artifactId>
-        <version>${shindig.version}</version>
         <type>war</type>
 	</dependency>
 	<dependency>
         <groupId>org.apache.shindig</groupId>
         <artifactId>shindig-features</artifactId>
-        <version>${shindig.version}</version>
 	</dependency>
 	<dependency>
 		<groupId>org.apache.shindig</groupId>
 		<artifactId>shindig-common</artifactId>
-		<version>${shindig.version}</version>
         <exclusions>
             <exclusion>
                 <groupId>org.apache.tomcat</groupId>
@@ -39,30 +35,25 @@
 	<dependency>
 		<groupId>org.apache.shindig</groupId>
 		<artifactId>shindig-gadgets</artifactId>
-		<version>${shindig.version}</version>
 	</dependency>
 	<dependency>
 		<groupId>org.apache.shindig</groupId>
 		<artifactId>shindig-social-api</artifactId>
-		<version>${shindig.version}</version>
 	</dependency>
 	<dependency>
 		<groupId>org.apache.shindig</groupId>
 		<artifactId>shindig-extras</artifactId>
-		<version>${shindig.version}</version>
 	</dependency>
 
      <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
          <scope>test</scope>
-         <version>4.10</version>
      </dependency>
 
       <dependency>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
-          <version>${log4j.version}</version>
       </dependency>
   </dependencies>
 

--- a/gadget-web/pom.xml
+++ b/gadget-web/pom.xml
@@ -10,19 +10,13 @@
   <groupId>org.overlord.gadgets.server</groupId>
   <artifactId>gadget-web</artifactId>
   <packaging>war</packaging>
-  <version>1.0.0-SNAPSHOT</version>
   <name>Gadget Server::Web</name>
 
   <properties>
     <!-- GWT needs at least java 1.5 -->
     <maven.compiler.source>1.5</maven.compiler.source>
     <maven.compiler.target>1.5</maven.compiler.target>
-	<gwt.version>2.3.0</gwt.version>
     <webappDirectory>${project.build.directory}/${project.build.finalName}</webappDirectory>
-	<gwt-log.version>3.1.3</gwt-log.version>
-	<gin.version>1.5_past22</gin.version>
-	<gwtp.version>0.6</gwtp.version>
-	<gwt-vis.version>1.1.1</gwt-vis.version>
 	
   </properties>
 
@@ -30,59 +24,49 @@
     <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-servlet</artifactId>
-	  <version>${gwt.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-user</artifactId>
-	  <version>${gwt.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-	  <version>${guice.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.gwt.inject</groupId>
       <artifactId>gin</artifactId>
-	  <version>${gin.version}</version>
     </dependency>
     <dependency>
       <groupId>com.gwtplatform</groupId>
       <artifactId>gwtp-mvp-client</artifactId>
-	  <version>${gwtp.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-assistedinject</artifactId>
-	  <version>${guice.version}</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.code.gwt-log</groupId>
       <artifactId>gwt-log</artifactId>
-	  <version>${gwt-log.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     
     <dependency>
         <groupId>javax.enterprise</groupId>
         <artifactId>cdi-api</artifactId>
-        <version>1.0</version>
         <scope>provided</scope>
     </dependency>
 
     <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.1</version>
     </dependency>
 
     <dependency>
@@ -94,17 +78,18 @@
       <dependency>
           <groupId>org.jboss.resteasy</groupId>
           <artifactId>resteasy-jaxrs</artifactId>
-          <version>${resteasy.version}</version>
       </dependency>
       <dependency>
           <groupId>org.jboss.resteasy</groupId>
           <artifactId>resteasy-jackson-provider</artifactId>
-          <version>${resteasy.version}</version>
       </dependency>
+	<dependency>
+		<groupId>org.jboss.spec.javax.ws.rs</groupId>
+		<artifactId>jboss-jaxrs-api_1.1_spec</artifactId>
+	</dependency>
       <dependency>
           <groupId>org.jboss.resteasy</groupId>
           <artifactId>resteasy-guice</artifactId>
-          <version>${resteasy.version}</version>
           <exclusions>
               <exclusion>
                   <groupId>com.google.code.guice</groupId>
@@ -115,7 +100,6 @@
       <dependency>
           <groupId>com.google.code.gson</groupId>
           <artifactId>gson</artifactId>
-          <version>1.2.2</version>
       </dependency>
 
 
@@ -123,13 +107,11 @@
       <dependency>
           <groupId>org.json</groupId>
           <artifactId>json</artifactId>
-          <version>20090211</version>
       </dependency>
 
       <dependency>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
-          <version>${log4j.version}</version>
       </dependency>
 
   </dependencies>
@@ -144,7 +126,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
-        <version>2.3.0</version>
         <executions>
           <execution>
             <goals>
@@ -163,7 +144,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.1.1</version>
         <executions>
           <execution>
             <phase>compile</phase>

--- a/gadgets/pom.xml
+++ b/gadgets/pom.xml
@@ -10,7 +10,6 @@
   <groupId>org.overlord.gadgets.server</groupId>
   <artifactId>gadgets</artifactId>
   <packaging>war</packaging>
-  <version>1.0.0-SNAPSHOT</version>
   <name>Gadget Server::Demo Gadgets</name>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -7,10 +7,16 @@
 	<version>1.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Gadget Server</name>
-	<url>http://www.savara.org</url>
+	<url>http://www.jboss.org/overlord</url>
 	<description>
 		The Gadget Server project
 	</description>
+
+	<parent>
+		<groupId>org.jboss</groupId>
+		<artifactId>jboss-parent</artifactId>
+		<version>8</version>
+	</parent>
 
 	<scm>
 		<connection>https://github.com/governance</connection>
@@ -50,15 +56,18 @@
 	</developers>
 
 	<properties>
-	<junit.version>4.4</junit.version>
-        <shindig.version>3.0.0-beta4</shindig.version>
-        <guice.version>3.0</guice.version>
-        <persistence-api.version>1.0.1.Final</persistence-api.version>
-        <hibernate.version>4.0.1.Final</hibernate.version>
-        <javassist.version>3.12.1.GA</javassist.version>
-        <h2.version>1.3.161</h2.version>
-        <resteasy.version>2.2.1.GA</resteasy.version>
-        <log4j.version>1.6.1</log4j.version>
+		<json.version>20090211</json.version>
+		<gin.version>1.5_past22</gin.version>
+		<gson.version>1.2.2</gson.version>
+		<guice.version>3.0</guice.version>
+		<gwt.version>2.3.0</gwt.version>
+		<gwt-log.version>3.1.3</gwt-log.version>
+		<gwtp.version>0.6</gwtp.version>
+		<gwt-vis.version>1.1.1</gwt-vis.version>
+		<jbossas.version>7.1.1.Final</jbossas.version>
+		<resteasy.version>2.3.2.Final</resteasy.version>
+        	<shindig.version>3.0.0-beta4</shindig.version>
+		<slf4j.version>1.6.1</slf4j.version>
 	</properties>
 
 	<modules>
@@ -69,6 +78,113 @@
           <module>distribution</module>
 	</modules>
 
+	<dependencyManagement>
+		<dependencies>
+			<!-- Imported dependencies -->
+			<dependency>
+				<groupId>org.jboss.as</groupId>
+				<artifactId>jboss-as-parent</artifactId>
+				<version>${jbossas.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+
+ 			<dependency>
+				<groupId>org.apache.shindig</groupId>
+				<artifactId>shindig-common</artifactId>
+				<type>jar</type>
+				<version>${shindig.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.shindig</groupId>
+				<artifactId>shindig-server</artifactId>
+				<version>${shindig.version}</version>
+				<type>war</type>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.shindig</groupId>
+				<artifactId>shindig-features</artifactId>
+				<version>${shindig.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.shindig</groupId>
+				<artifactId>shindig-gadgets</artifactId>
+				<version>${shindig.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.shindig</groupId>
+				<artifactId>shindig-social-api</artifactId>
+				<version>${shindig.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.shindig</groupId>
+				<artifactId>shindig-extras</artifactId>
+				<version>${shindig.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.google.inject</groupId>
+				<artifactId>guice</artifactId>
+				<version>${guice.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-log4j12</artifactId>
+				<version>${slf4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.google.gwt</groupId>
+				<artifactId>gwt-servlet</artifactId>
+				<version>${gwt.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.google.gwt</groupId>
+				<artifactId>gwt-user</artifactId>
+				<version>${gwt.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.google.inject</groupId>
+				<artifactId>guice</artifactId>
+				<version>${guice.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.google.gwt.inject</groupId>
+				<artifactId>gin</artifactId>
+				<version>${gin.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.gwtplatform</groupId>
+				<artifactId>gwtp-mvp-client</artifactId>
+				<version>${gwtp.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.google.inject.extensions</groupId>
+				<artifactId>guice-assistedinject</artifactId>
+				<version>${guice.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.google.code.gwt-log</groupId>
+				<artifactId>gwt-log</artifactId>
+				<version>${gwt-log.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jboss.resteasy</groupId>
+				<artifactId>resteasy-guice</artifactId>
+				<version>${resteasy.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.json</groupId>
+				<artifactId>json</artifactId>
+				<version>${json.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.google.code.gson</groupId>
+				<artifactId>gson</artifactId>
+				<version>${gson.version}</version>
+			</dependency>
+
+		</dependencies>
+	</dependencyManagement>
+
 	<build>
 		<!-- This section defines the default plugin settings inherited by child projects. -->
 		<pluginManagement>
@@ -77,15 +193,18 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
-					<version>2.2</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>2.2</version>
 					<configuration>
 						<aggregate>true</aggregate>
 					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>gwt-maven-plugin</artifactId>
+					<version>2.3.0</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>
@@ -94,7 +213,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-                <version>2.0.2</version>
 				<configuration>
 					<source>1.5</source>
 					<target>1.5</target>
@@ -106,7 +224,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>2.1.2</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>
@@ -120,7 +237,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.7.2</version>
 				<configuration>
 					<includes>
 						<include>**/*TestCase.java</include>
@@ -136,7 +252,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>2.7.2</version>
 			</plugin>
 	    </plugins>
 	</reporting>


### PR DESCRIPTION
Changed the poms to import jbossas bom and use jbossas parent, to make it easier to integrate into a jbossas based platform, to avoid version conflicts.

However when testing with BAM noticed an exception (npe) in the REST service - double checked and the master seemed to have the same problem, so doesn't look like it was introduced due to these changes, although you may want to verify this before pushing the change.

The exception occurred when adding a gadget from the gadget store.
