### PR TITLE
gadget-server.properties now supports property interpolation

### DIFF
--- a/gadget-core/pom.xml
+++ b/gadget-core/pom.xml
@@ -62,8 +62,20 @@
               </exclusion>
           </exclusions>
       </dependency>
+      
+    <dependency>
+      <groupId>org.overlord</groupId>
+      <artifactId>overlord-commons-config</artifactId>
+      <version>${overlord-commons.version}</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>${commons-logging.version}</version>
+    </dependency>
 
-     <dependency>
+    <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
          <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
 		<jbossas.version>7.2.0.Final</jbossas.version>
 		<nekohtml.version>1.9.15</nekohtml.version>
 		<shindig.version>3.0.0-beta4</shindig.version>
+        <commons-logging.version>1.1.1</commons-logging.version>
 		<overlord-commons.version>2.0.0-SNAPSHOT</overlord-commons.version>
 	</properties>
 


### PR DESCRIPTION
fixed a problem where properties were not being interpolated in the gadget-server.properties 
file (were not using commons config)
